### PR TITLE
[feat] 게시판 단일조회 세부정보에 게시판 하위 게시글, 댓글 개수 정보 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,12 @@ dependencies {
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	// queryDSL 설정
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 	// Websocket
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 

--- a/src/main/java/com/totalhubsite/backend/domain/board/dto/response/BoardDetailResponseDto.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/dto/response/BoardDetailResponseDto.java
@@ -9,17 +9,20 @@ public record BoardDetailResponseDto(
     Long id,
     String name,
     String description,
+    Long boardCount,
+    Long commentCount,
     MemberInfoResponseDto member
 
 ) {
 
     @Builder
-
-    public BoardDetailResponseDto(Long id, String name, String description,
-        MemberInfoResponseDto member) {
+    public BoardDetailResponseDto(Long id, String name, String description, Long boardCount,
+        Long commentCount, MemberInfoResponseDto member) {
         this.id = id;
         this.name = name;
         this.description = description;
+        this.boardCount = boardCount;
+        this.commentCount = commentCount;
         this.member = member;
     }
 
@@ -31,6 +34,20 @@ public record BoardDetailResponseDto(
             .id(entity.getId())
             .name(entity.getName())
             .description(entity.getDescription())
+            .member(memberInfo)
+            .build();
+    }
+
+    public static BoardDetailResponseDto fromEntity(Board entity, Long boardCount, Long commentCount) {
+        Member findMember = entity.getMember();
+        MemberInfoResponseDto memberInfo = MemberInfoResponseDto.fromEntity(findMember);
+
+        return BoardDetailResponseDto.builder()
+            .id(entity.getId())
+            .name(entity.getName())
+            .description(entity.getDescription())
+            .boardCount(boardCount)
+            .commentCount(commentCount)
             .member(memberInfo)
             .build();
     }

--- a/src/main/java/com/totalhubsite/backend/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/repository/BoardRepository.java
@@ -1,8 +1,0 @@
-package com.totalhubsite.backend.domain.board.repository;
-
-import com.totalhubsite.backend.domain.board.entity.Board;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface BoardRepository extends JpaRepository<Board, Long> {
-
-}

--- a/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardCustomRepository.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardCustomRepository.java
@@ -1,0 +1,9 @@
+package com.totalhubsite.backend.domain.board.repository.board;
+
+import com.totalhubsite.backend.domain.board.dto.response.BoardDetailResponseDto;
+
+public interface BoardCustomRepository {
+
+    BoardDetailResponseDto findBoardDetails(Long boardId);
+
+}

--- a/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardCustomRepositoryImpl.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardCustomRepositoryImpl.java
@@ -1,0 +1,61 @@
+package com.totalhubsite.backend.domain.board.repository.board;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.totalhubsite.backend.domain.board.dto.response.BoardDetailResponseDto;
+import com.totalhubsite.backend.domain.board.entity.QBoard;
+import com.totalhubsite.backend.domain.board.entity.QComment;
+import com.totalhubsite.backend.domain.board.entity.QPost;
+import com.totalhubsite.backend.domain.member.dto.response.MemberInfoResponseDto;
+import jakarta.persistence.EntityManager;
+
+public class BoardCustomRepositoryImpl implements BoardCustomRepository{
+
+    private final JPAQueryFactory queryFactory;
+
+    public BoardCustomRepositoryImpl(EntityManager entityManager) {
+        this.queryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public BoardDetailResponseDto findBoardDetails(Long boardId) {
+
+        QBoard qBoard = QBoard.board;
+        QPost qPost = QPost.post;
+        QComment qComment = QComment.comment;
+
+        // 각 정보에 대한 요청
+//        Board board = queryFactory.selectFrom(qBoard)
+//            .where(qBoard.id.eq(boardId))
+//            .fetchOne();
+//
+//        Long postCount = queryFactory.select(qPost.count())
+//            .from(qPost)
+//            .where(qPost.board.id.eq(boardId))
+//            .fetchOne();
+//
+//        Long commentCount = queryFactory.select(qComment.count())
+//            .from(qComment)
+//            .where(qComment.post.board.id.eq(boardId))
+//            .fetchOne();
+//
+//        BoardDetailResponseDto responseDto = BoardDetailResponseDto.fromEntity(board, postCount, commentCount);
+
+        // 한번의 요청으로 처리
+        BoardDetailResponseDto responseDto  = queryFactory
+            .select(Projections.constructor(BoardDetailResponseDto.class,
+                qBoard.id,
+                qBoard.name,
+                qBoard.description,
+                JPAExpressions.select(qPost.count()).from(qPost).where(qPost.board.id.eq(boardId)),
+                JPAExpressions.select(qComment.count()).from(qComment).where(qComment.post.board.id.eq(boardId)),
+                Projections.constructor(MemberInfoResponseDto.class, qBoard.member.id, qBoard.member.nickname)
+            ))
+            .from(qBoard)
+            .where(qBoard.id.eq(boardId))
+            .fetchOne();
+
+        return responseDto;
+    }
+}

--- a/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardRepository.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/repository/board/BoardRepository.java
@@ -1,0 +1,11 @@
+package com.totalhubsite.backend.domain.board.repository.board;
+
+import com.totalhubsite.backend.domain.board.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends
+    JpaRepository<Board, Long>,
+    BoardCustomRepository
+{
+
+}

--- a/src/main/java/com/totalhubsite/backend/domain/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/service/BoardServiceImpl.java
@@ -5,7 +5,7 @@ import com.totalhubsite.backend.domain.board.dto.response.BoardDetailResponseDto
 import com.totalhubsite.backend.domain.board.dto.response.BoardListResponseDto;
 import com.totalhubsite.backend.domain.board.entity.Board;
 import com.totalhubsite.backend.domain.board.exception.BoardNotFoundException;
-import com.totalhubsite.backend.domain.board.repository.BoardRepository;
+import com.totalhubsite.backend.domain.board.repository.board.BoardRepository;
 import com.totalhubsite.backend.domain.member.entity.Member;
 import com.totalhubsite.backend.domain.member.exception.PermissionDeniedException;
 import com.totalhubsite.backend.global.security.dto.PrincipalDetails;
@@ -40,9 +40,11 @@ public class BoardServiceImpl implements BoardService{
     @Override @Transactional(readOnly = true)
     public BoardDetailResponseDto findBoard(Long boardId) {
 
-        Board findBoard = findBoardById(boardId);
+//        Board findBoard = findBoardById(boardId);
 
-        BoardDetailResponseDto responseDto = BoardDetailResponseDto.fromEntity(findBoard);
+//        BoardDetailResponseDto responseDto = BoardDetailResponseDto.fromEntity(findBoard);
+
+        BoardDetailResponseDto responseDto = boardRepository.findBoardDetails(boardId);
 
         return responseDto;
     }

--- a/src/main/java/com/totalhubsite/backend/domain/board/service/PostServiceImpl.java
+++ b/src/main/java/com/totalhubsite/backend/domain/board/service/PostServiceImpl.java
@@ -6,7 +6,7 @@ import com.totalhubsite.backend.domain.board.dto.response.PostListResponseDto;
 import com.totalhubsite.backend.domain.board.entity.Board;
 import com.totalhubsite.backend.domain.board.entity.Post;
 import com.totalhubsite.backend.domain.board.exception.BoardNotFoundException;
-import com.totalhubsite.backend.domain.board.repository.BoardRepository;
+import com.totalhubsite.backend.domain.board.repository.board.BoardRepository;
 import com.totalhubsite.backend.domain.board.repository.PostRepository;
 import com.totalhubsite.backend.domain.member.exception.PermissionDeniedException;
 import com.totalhubsite.backend.global.security.dto.PrincipalDetails;


### PR DESCRIPTION
- querydsl 사용
- 일단 요청마다 개수 계산하여 처리